### PR TITLE
Added an access hack to add support for blueprint function libraries

### DIFF
--- a/Source/HardReferenceFinder/Private/HardReferenceFinderSearchData.cpp
+++ b/Source/HardReferenceFinder/Private/HardReferenceFinderSearchData.cpp
@@ -125,7 +125,12 @@ UObject* FHardReferenceFinderSearchData::GetObjectContext(TWeakPtr<FBlueprintEdi
 	SSubobjectEditor* SubobjectEditorWidget = SubobjectEditorPtr.Get();
 	if(SubobjectEditorWidget == nullptr)
 	{
-		return nullptr;
+		class BlueprintEditorEditingObject_AccessHack : public FBlueprintEditor
+		{
+		public:
+			UObject* GetEditingObject_Expose() const { return GetEditingObject(); }
+		};
+		return static_cast<BlueprintEditorEditingObject_AccessHack*>(BlueprintEditor.Pin().Get())->GetEditingObject_Expose();
 	}
 		
 	UObject* Object = SubobjectEditorWidget->GetObjectContext();


### PR DESCRIPTION
Now we can get the object the blueprint editor is editing in cases that weren't working with the existing code, such as blueprint function libraries.