### PR TITLE
Engine compatibility changes

### DIFF
--- a/Source/HardReferenceFinder/Private/HardReferenceFinderSearchData.cpp
+++ b/Source/HardReferenceFinder/Private/HardReferenceFinderSearchData.cpp
@@ -444,13 +444,11 @@ TArray<UPackage*> FHardReferenceFinderSearchData::FindPackagesForProperty(FSlate
 		}
 	}
 
-
-#if ENGINE_MAJOR_VERSION==5 && ENGINE_MINOR_VERSION>=3
-	typedef const TArray<TObjectPtr<UObject>>* FObjectArray;
-#else
+#if UE_VERSION_OLDER_THAN(5,3,0)
 	typedef const TArray<UObject*>* FObjectArray;
+#else
+	typedef const TArray<TObjectPtr<UObject>>* FObjectArray;
 #endif
-	
 	FObjectArray ScriptAndPropertyObjectReferences = nullptr;
 	if(const FObjectPropertyBase* ObjectProperty = CastField<FObjectPropertyBase>(TargetProperty))
 	{

--- a/Source/HardReferenceFinder/Private/HardReferenceFinderSearchData.cpp
+++ b/Source/HardReferenceFinder/Private/HardReferenceFinderSearchData.cpp
@@ -113,29 +113,12 @@ UObject* FHardReferenceFinderSearchData::GetObjectContext(TWeakPtr<FBlueprintEdi
 		return nullptr;
 	}
 
-#if ENGINE_MAJOR_VERSION < 5
-	TSharedPtr<class SSCSEditor> SCSEditorPtr = BlueprintEditor.Pin()->GetSCSEditor();
-	if(!SCSEditorPtr.IsValid())
+	class BlueprintEditorEditingObject_AccessHack : public FBlueprintEditor
 	{
-		return nullptr;
-	}
-	return SCSEditorPtr->GetActorContext();
-#else
-	TSharedPtr<SSubobjectEditor> SubobjectEditorPtr = BlueprintEditor.Pin()->GetSubobjectEditor();
-	SSubobjectEditor* SubobjectEditorWidget = SubobjectEditorPtr.Get();
-	if(SubobjectEditorWidget == nullptr)
-	{
-		class BlueprintEditorEditingObject_AccessHack : public FBlueprintEditor
-		{
-		public:
-			UObject* GetEditingObject_Expose() const { return GetEditingObject(); }
-		};
-		return static_cast<BlueprintEditorEditingObject_AccessHack*>(BlueprintEditor.Pin().Get())->GetEditingObject_Expose();
-	}
-		
-	UObject* Object = SubobjectEditorWidget->GetObjectContext();
-	return Object;
-#endif
+	public:
+		UObject* GetEditingObject_Expose() const { return GetEditingObject(); }
+	};
+	return static_cast<BlueprintEditorEditingObject_AccessHack*>(BlueprintEditor.Pin().Get())->GetEditingObject_Expose();
 }
 
 void FHardReferenceFinderSearchData::GetBlueprintDependencies(TArray<FName>& OutPackageDependencies, FAssetRegistryModule& AssetRegistryModule, TWeakPtr<FBlueprintEditor> BlueprintEditor) const

--- a/Source/HardReferenceFinder/Private/HardReferenceFinderSearchData.cpp
+++ b/Source/HardReferenceFinder/Private/HardReferenceFinderSearchData.cpp
@@ -443,8 +443,15 @@ TArray<UPackage*> FHardReferenceFinderSearchData::FindPackagesForProperty(FSlate
 			}
 		}
 	}
+
+
+#if ENGINE_MAJOR_VERSION==5 && ENGINE_MINOR_VERSION>=3
+	typedef const TArray<TObjectPtr<UObject>>* FObjectArray;
+#else
+	typedef const TArray<UObject*>* FObjectArray;
+#endif
 	
-	const TArray<UObject*>* ScriptAndPropertyObjectReferences = nullptr;
+	FObjectArray ScriptAndPropertyObjectReferences = nullptr;
 	if(const FObjectPropertyBase* ObjectProperty = CastField<FObjectPropertyBase>(TargetProperty))
 	{
 		ScriptAndPropertyObjectReferences = &ObjectProperty->PropertyClass->ScriptAndPropertyObjectReferences;

--- a/Source/HardReferenceFinder/Private/SHardReferenceFinderWindow.cpp
+++ b/Source/HardReferenceFinder/Private/SHardReferenceFinderWindow.cpp
@@ -169,6 +169,11 @@ bool SHardReferenceFinderWindow::BringAttentionToSCSNode(const FName& SCSIdentif
 		return false;
 	}
 
+	if(Blueprint->SimpleConstructionScript == nullptr)
+	{
+		return false;	
+	}
+
 	UBlueprintGeneratedClass* GeneratedClass = Cast<UBlueprintGeneratedClass>(Blueprint->GeneratedClass);
 	if(GeneratedClass == nullptr)
 	{


### PR DESCRIPTION
- Fixes so the plugin compiles in UE 5.3
- Function library searching support now includes UE 4.27
- Fixing a possible crash when double clicking member variables in a graph without a SCS